### PR TITLE
fix/env-variables-mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A Laravel package for interacting with the [Listmonk API](https://listmonk.app/d
 
     ```env
     LISTMONK_BASE_URL=
-    LISTMONK_API_USERE=
+    LISTMONK_API_USER=
     LISTMONK_API_TOKEN=
     ```
 


### PR DESCRIPTION
**Misleading env variables fix**
<details><summary>Details</summary>
<p>
While i was implementing this faced a problem when using env variables, had to go through the code to find out the mismatch in documentation (Readme) (Fixed)


</p>
</details> 

